### PR TITLE
Removed `echo package name $pkgname`

### DIFF
--- a/instantassist/PKGBUILD
+++ b/instantassist/PKGBUILD
@@ -1,6 +1,5 @@
 # Maintainer: paperbenni <paperbenni@gmail.com>
 pkgname=instantassist
-echo package name $pkgname
 _pkgname=instantassist
 pkgver=202005271447
 pkgrel=1


### PR DESCRIPTION
Removed `echo package name $pkgname`
which in turn, solves errors when trying to push to the AUR.